### PR TITLE
mark optim tests that depend on assets as flaky

### DIFF
--- a/tests/integration/test_optim.py
+++ b/tests/integration/test_optim.py
@@ -46,6 +46,7 @@ def test_image_optimization_optimizer_preprocessor():
 
 
 @skip_if_py38
+@pytest.mark.flaky
 def test_default_image_optim_loop(optim_asset_loader):
     asset = optim_asset_loader("default_image_optim_loop")
 
@@ -65,6 +66,7 @@ def test_default_image_optim_loop(optim_asset_loader):
     "'pystiche.image.transforms' is needed to load the asset, "
     "but is no longer accessible."
 )
+@pytest.mark.flaky
 def test_default_image_optim_loop_processing(optim_asset_loader):
     asset = optim_asset_loader("default_image_optim_loop_processing")
 
@@ -82,6 +84,7 @@ def test_default_image_optim_loop_processing(optim_asset_loader):
 
 
 @skip_if_py38
+@pytest.mark.flaky
 def test_default_image_pyramid_optim_loop(optim_asset_loader):
     asset = optim_asset_loader("default_image_pyramid_optim_loop")
 
@@ -97,6 +100,7 @@ def test_default_image_pyramid_optim_loop(optim_asset_loader):
 
 
 @skip_if_py38
+@pytest.mark.flaky
 def test_default_image_pyramid_optim_loop_processing(optim_asset_loader):
     asset = optim_asset_loader("default_image_pyramid_optim_loop")
 
@@ -135,6 +139,7 @@ def make_torch_ge_1_6_compatible(image_loader, criterion):
 
 
 @skip_if_py38
+@pytest.mark.flaky
 def test_default_transformer_optim_loop(optim_asset_loader):
     asset = optim_asset_loader("default_transformer_optim_loop")
 
@@ -159,6 +164,7 @@ def test_default_transformer_optim_loop(optim_asset_loader):
 
 
 @skip_if_py38
+@pytest.mark.flaky
 def test_default_transformer_epoch_optim_loop(optim_asset_loader):
     asset = optim_asset_loader("default_transformer_epoch_optim_loop")
 


### PR DESCRIPTION
Addresses #486. This should be properly fixed in the future.