### PR TITLE
add CI tests for all supported minor PyTorch releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,24 +29,40 @@ jobs:
   integration:
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+        os:
+          - "ubuntu-latest"
+        torch:
+          - "1.8.1"
         include:
-          - os: windows-latest
-            python: "3.6"
-          - os: macos-latest
-            python: "3.6"
+          - python: "3.6"
+            os: "windows-latest"
+            torch: "1.8.1"
+          - python: "3.6"
+            os: "macos-latest"
+            torch:  "1.8.1"
+          - python: "3.6"
+            os: "ubuntu-latest"
+            torch: "1.6.0"
+          - python: "3.6"
+            os: "ubuntu-latest"
+            torch: "1.7.1"
 
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}
+      TORCH: ${{ matrix.torch }}
 
     steps:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: $PYTHON
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
@@ -63,7 +79,7 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Create environment
-        run: tox -e tests-integration --notest
+        run: tox -e tests-integration --force-dep torch==$TORCH --notest
 
       - name: Run tests
         run: tox -e tests-integration -- --skip-large-download
@@ -71,7 +87,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1.5.0
         with:
-          env_vars: OS,PYTHON
+          env_vars: OS,PYTHON,TORCH
 
   galleries:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Install dev requirements
         run: pip install -r requirements-dev.txt
 
+      - name: Debug
+        run: |
+          echo $TORCH
+          echo $TORCHVISION
+
       - name: Create environment
         run: >
           tox -e tests-integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: $PYTHON
+          python-version: ${{ matrix.python }}
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,11 @@ jobs:
           --notest
 
       - name: Run tests
-        run: tox -e tests-integration -- --skip-large-download
+        run: >
+          tox -e tests-integration
+          --force-dep torch==${{ matrix.torch }}
+          --force-dep torchvision==${{ matrix.torchvision }}
+          -- --skip-large-download
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1.5.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,25 +38,32 @@ jobs:
           - "ubuntu-latest"
         torch:
           - "1.8.1"
+        torchvision:
+          - "0.9.1"
         include:
           - python: "3.6"
             os: "windows-latest"
             torch: "1.8.1"
+            torchvision: "0.9.1"
           - python: "3.6"
             os: "macos-latest"
             torch:  "1.8.1"
+            torchvision: "0.9.1"
           - python: "3.6"
             os: "ubuntu-latest"
             torch: "1.6.0"
+            torchvision: "0.7.0"
           - python: "3.6"
             os: "ubuntu-latest"
             torch: "1.7.1"
+            torchvision: "0.8.2"
 
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}
       TORCH: ${{ matrix.torch }}
+      TORCHVISION: ${{ matrix.torchvision }}
 
     steps:
       - name: Set up python
@@ -79,7 +86,11 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Create environment
-        run: tox -e tests-integration --force-dep torch==$TORCH --notest
+        run: |
+          tox -e tests-integration
+          --force-dep torch==$TORCH
+          --force-dep torchvision==$TORCHVISION
+          --notest
 
       - name: Run tests
         run: tox -e tests-integration -- --skip-large-download

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,11 +85,6 @@ jobs:
       - name: Install dev requirements
         run: pip install -r requirements-dev.txt
 
-      - name: Debug
-        run: |
-          echo ${{ matrix.torch }}
-          echo ${{ matrix.torchvision }}
-
       - name: Create environment
         run: >
           tox -e tests-integration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Create environment
-        run: |
+        run: >
           tox -e tests-integration
           --force-dep torch==$TORCH
           --force-dep torchvision==$TORCHVISION

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,14 +87,14 @@ jobs:
 
       - name: Debug
         run: |
-          echo $TORCH
-          echo $TORCHVISION
+          echo ${{ matrix.torch }}
+          echo ${{ matrix.torchvision }}
 
       - name: Create environment
         run: >
           tox -e tests-integration
-          --force-dep torch==$TORCH
-          --force-dep torchvision==$TORCHVISION
+          --force-dep torch==${{ matrix.torch }}
+          --force-dep torchvision==${{ matrix.torchvision }}
           --notest
 
       - name: Run tests

--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -152,7 +152,13 @@ class MultiLayerEncoder(pystiche.Module):
         self._cache: DefaultDict[torch.Tensor, Dict[str, torch.Tensor]] = defaultdict(
             lambda: {}
         )
-        self.register_full_backward_hook(
+
+        register = (
+            self.register_backward_hook
+            if torch.__version__ < "1.8"
+            else self.register_full_backward_hook
+        )
+        register(
             MultiLayerEncoder.__backward_hook__  # type:ignore[arg-type]
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,9 @@ deps =
   pillow_affine
   pyimagetest >= 0.3
   pillow_affine
+  # we need to include it here to be able to override the specific version with
+  # --force-dep
+  torch
 commands =
   {[tests-common]commands} \
     --cov=pystiche \

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,10 @@ deps =
   pillow_affine
   pyimagetest >= 0.3
   pillow_affine
-  # we need to include it here to be able to override the specific version with
+  # we need to include these here to be able to override the specific version with
   # --force-dep
   torch
+  torchvision
 commands =
   {[tests-common]commands} \
     --cov=pystiche \


### PR DESCRIPTION
As of #488 `pystiche` can run with multiple PyTorch versions. Thus, we should test all of them to make sure we don't include BC incompatible changes.