### PR TITLE
run CI also on dev branches

### DIFF
--- a/.github/workflows/lint-style.yml
+++ b/.github/workflows/lint-style.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev/*
       - releases/*
 
   pull_request:

--- a/.github/workflows/lint-typing.yml
+++ b/.github/workflows/lint-typing.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev/*
       - releases/*
 
   pull_request:

--- a/.github/workflows/publishable.yml
+++ b/.github/workflows/publishable.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev/*
       - releases/*
 
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev/*
       - releases/*
 
   pull_request:


### PR DESCRIPTION
This should make large scope changes easier by running CI on `dev/` branches