### PR TITLE
pin `pillow<8.3`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     torch>=1.6
     torchvision>=0.7
     kornia==0.4.1
-    pillow
+    pillow<8.3
     tqdm
 
 [options.packages.find]


### PR DESCRIPTION
See pytorch/vision#4146 which is the driver for our image I/O. In the future we might simply explicitly use `pillow!=8.3.0` instead of requiring it to be `<8.3`.