### PR TITLE
fix MLE auto cache clearing

### DIFF
--- a/pystiche/enc/multi_layer_encoder.py
+++ b/pystiche/enc/multi_layer_encoder.py
@@ -12,7 +12,6 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Union,
     cast,
 )
 
@@ -153,15 +152,6 @@ class MultiLayerEncoder(pystiche.Module):
             lambda: {}
         )
 
-        register = (
-            self.register_backward_hook
-            if torch.__version__ < "1.8"
-            else self.register_full_backward_hook
-        )
-        register(
-            MultiLayerEncoder.__backward_hook__  # type:ignore[arg-type]
-        )
-
     def __contains__(self, layer: str) -> bool:
         r"""Is the layer part of the multi-layer encoder?
 
@@ -219,6 +209,8 @@ class MultiLayerEncoder(pystiche.Module):
 
         if cache is None:
             cache = self._cache[input]
+            if input.requires_grad:
+                input.register_hook(lambda grad: self.clear_cache())
         if layer in cache:
             return cache[layer]
 
@@ -247,13 +239,6 @@ class MultiLayerEncoder(pystiche.Module):
             "The method 'empty_storage'", "1.0", info="It was renamed to 'clear_cache'."
         )
         warnings.warn(msg)
-        self.clear_cache()
-
-    def __backward_hook__(
-        self,
-        grad_input: Union[Tuple[torch.Tensor, ...], torch.Tensor],
-        grad_output: Union[Tuple[torch.Tensor, ...], torch.Tensor],
-    ) -> None:
         self.clear_cache()
 
     def encode(


### PR DESCRIPTION
#495 regressed performance, because the internal caching of an `enc.MultiLayerEncoder` is broken if a full backward hook is used. See pytorch/pytorch#61446 for details. With this we now attach the hook to the input tensor rather than the module.