### PR TITLE
fix development status classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ author = Philip Meier
 author-email = github.pmeier@posteo.de
 license = BSD-3-Clause
 classifiers =
-    Development Status :: 5 - Stable
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     Intended Audience :: Education
     Intended Audience :: Science/Research


### PR DESCRIPTION
PyPI seems to reject releases unless the classifier is properly set :roll_eyes: