### PR TITLE
changes to make workflows run on main branch instead of master

### DIFF
--- a/.github/workflows/lint-style.yml
+++ b/.github/workflows/lint-style.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches:
-      - master
+      - main
       - dev/*
       - releases/*
 

--- a/.github/workflows/lint-typing.yml
+++ b/.github/workflows/lint-typing.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches:
-      - master
+      - main
       - dev/*
       - releases/*
 

--- a/.github/workflows/publishable.yml
+++ b/.github/workflows/publishable.yml
@@ -3,7 +3,7 @@ name: publishable
 on:
   push:
     branches:
-      - master
+      - main
       - dev/*
       - releases/*
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - main
       - dev/*
       - releases/*
 


### PR DESCRIPTION
The changes are to make CI checks run on the main branch instead of master in reference to issue number  [510](https://github.com/pystiche/pystiche/issues/510)