### PR TITLE
fix docs version string

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,8 +41,7 @@ def project():
     author = metadata["author"]
     copyright = f"{datetime.now().year}, {author}"
     release = metadata["version"]
-    canonical_version = release.split("+")[0]
-    version = ".".join(canonical_version.split(".")[:3])
+    version = release.split(".dev")[0]
     config = dict(
         project=project,
         author=author,


### PR DESCRIPTION
Without this fix versions that include more than 3 parts, such as our current stable version `1.0.0.post0`, will not be recognized.