### PR TITLE
Test suite clean-up: Tests in `loss` and `image`

### DIFF
--- a/tests/integration/image/test_guides.py
+++ b/tests/integration/image/test_guides.py
@@ -57,29 +57,28 @@ def write_guide(guide, file):
     Image.fromarray(guide, mode="L").save(file)
 
 
-def test_verify_guides():
-    guides, _ = get_test_guides()
-    image.verify_guides(guides)
-
-
-def test_verify_guides_coverage():
-    guides, _ = get_test_guides()
-    del guides["R"]
-
-    with pytest.raises(RuntimeError):
+class TestVerifyGuides:
+    def test_main(self):
+        guides, _ = get_test_guides()
         image.verify_guides(guides)
 
-    image.verify_guides(guides, verify_coverage=False)
+    def test_coverage(self):
+        guides, _ = get_test_guides()
+        del guides["R"]
 
+        with pytest.raises(RuntimeError):
+            image.verify_guides(guides)
 
-def test_verify_guides_overlap():
-    guides, _ = get_test_guides()
-    guides["R2"] = guides["R"]
+        image.verify_guides(guides, verify_coverage=False)
 
-    with pytest.raises(RuntimeError):
-        image.verify_guides(guides)
+    def test_overlap(self):
+        guides, _ = get_test_guides()
+        guides["R2"] = guides["R"]
 
-    image.verify_guides(guides, verify_overlap=False)
+        with pytest.raises(RuntimeError):
+            image.verify_guides(guides)
+
+        image.verify_guides(guides, verify_overlap=False)
 
 
 def test_read_guides(tmpdir):

--- a/tests/integration/image/test_io.py
+++ b/tests/integration/image/test_io.py
@@ -8,36 +8,34 @@ import torch
 from pystiche import image as image_
 
 
-def test_read_image(test_image_file, test_image):
-    actual = image_.read_image(test_image_file)
-    desired = test_image
-    assert image_.is_batched_image(actual)
-    pyimagetest.assert_images_almost_equal(actual, desired)
+class TestReadImage:
+    def test_main(self, test_image_file, test_image):
+        actual = image_.read_image(test_image_file)
+        desired = test_image
+        assert image_.is_batched_image(actual)
+        pyimagetest.assert_images_almost_equal(actual, desired)
 
+    def test_resize(self, test_image_file, test_image_pil):
+        image_size = (200, 300)
+        actual = image_.read_image(test_image_file, size=image_size)
+        desired = test_image_pil.resize(image_size[::-1])
+        pyimagetest.assert_images_almost_equal(actual, desired)
 
-def test_read_image_resize(test_image_file, test_image_pil):
-    image_size = (200, 300)
-    actual = image_.read_image(test_image_file, size=image_size)
-    desired = test_image_pil.resize(image_size[::-1])
-    pyimagetest.assert_images_almost_equal(actual, desired)
+    def test_resize_scalar(self, test_image_file, test_image_pil):
+        edge_size = 200
 
+        aspect_ratio = image_.calculate_aspect_ratio(
+            (test_image_pil.height, test_image_pil.width)
+        )
+        image_size = image_.edge_to_image_size(edge_size, aspect_ratio)
 
-def test_read_image_resize_scalar(test_image_file, test_image_pil):
-    edge_size = 200
+        actual = image_.read_image(test_image_file, size=edge_size)
+        desired = test_image_pil.resize(image_size[::-1])
+        pyimagetest.assert_images_almost_equal(actual, desired)
 
-    aspect_ratio = image_.calculate_aspect_ratio(
-        (test_image_pil.height, test_image_pil.width)
-    )
-    image_size = image_.edge_to_image_size(edge_size, aspect_ratio)
-
-    actual = image_.read_image(test_image_file, size=edge_size)
-    desired = test_image_pil.resize(image_size[::-1])
-    pyimagetest.assert_images_almost_equal(actual, desired)
-
-
-def test_read_image_resize_other(test_image_file):
-    with pytest.raises(TypeError):
-        image_.read_image(test_image_file, size="invalid_size")
+    def test_resize_other(self, test_image_file):
+        with pytest.raises(TypeError):
+            image_.read_image(test_image_file, size="invalid_size")
 
 
 def test_write_image(tmpdir):

--- a/tests/integration/image/test_utils.py
+++ b/tests/integration/image/test_utils.py
@@ -157,59 +157,62 @@ def test_edge_to_image_size_vert_horz():
     assert actual == desired
 
 
-class TestExtract:
-    def test_batch_size(self):
-        batch_size = 3
+def test_extract_batch_size():
+    batch_size = 3
 
-        batched_image = torch.zeros(batch_size, 1, 1, 1)
-        actual = image_.extract_batch_size(batched_image)
-        desired = batch_size
-        assert actual == desired
+    batched_image = torch.zeros(batch_size, 1, 1, 1)
+    actual = image_.extract_batch_size(batched_image)
+    desired = batch_size
+    assert actual == desired
 
-        single_image = torch.zeros(1, 1, 1)
-        with pytest.raises(TypeError):
-            image_.extract_batch_size(single_image)
+    single_image = torch.zeros(1, 1, 1)
+    with pytest.raises(TypeError):
+        image_.extract_batch_size(single_image)
 
-    def test_num_channels(self):
-        num_channels = 3
 
-        single_image = torch.zeros(num_channels, 1, 1)
-        actual = image_.extract_num_channels(single_image)
-        desired = num_channels
-        assert actual == desired
+def test_extract_num_channels():
+    num_channels = 3
 
-        batched_image = single_image.unsqueeze(0)
-        actual = image_.extract_num_channels(batched_image)
-        desired = num_channels
-        assert actual == desired
+    single_image = torch.zeros(num_channels, 1, 1)
+    actual = image_.extract_num_channels(single_image)
+    desired = num_channels
+    assert actual == desired
 
-    def test_image_size(self):
-        height = 2
-        width = 3
-        image = torch.empty(1, 1, height, width)
+    batched_image = single_image.unsqueeze(0)
+    actual = image_.extract_num_channels(batched_image)
+    desired = num_channels
+    assert actual == desired
 
-        actual = image_.extract_image_size(image)
-        desired = (height, width)
-        assert actual == desired
 
-    def test_edge_size(self):
-        height = 2
-        width = 3
-        image = torch.empty(1, 1, height, width)
+def test_extract_image_size():
+    height = 2
+    width = 3
+    image = torch.empty(1, 1, height, width)
 
-        edges = ("short", "long", "vert", "horz")
-        actual = tuple(image_.extract_edge_size(image, edge=edge) for edge in edges)
-        desired = (height, width, height, width)
-        assert actual == desired
+    actual = image_.extract_image_size(image)
+    desired = (height, width)
+    assert actual == desired
 
-    def test_aspect_ratio(self):
-        height = 2
-        width = 3
-        image = torch.empty(1, 1, height, width)
 
-        actual = image_.extract_aspect_ratio(image)
-        desired = width / height
-        assert actual == pytest.approx(desired)
+def test_extract_edge_size():
+    height = 2
+    width = 3
+    image = torch.empty(1, 1, height, width)
+
+    edges = ("short", "long", "vert", "horz")
+    actual = tuple(image_.extract_edge_size(image, edge=edge) for edge in edges)
+    desired = (height, width, height, width)
+    assert actual == desired
+
+
+def test_extract_aspect_ratio():
+    height = 2
+    width = 3
+    image = torch.empty(1, 1, height, width)
+
+    actual = image_.extract_aspect_ratio(image)
+    desired = width / height
+    assert actual == pytest.approx(desired)
 
 
 class TestMakeImage:

--- a/tests/integration/image/test_utils.py
+++ b/tests/integration/image/test_utils.py
@@ -157,122 +157,118 @@ def test_edge_to_image_size_vert_horz():
     assert actual == desired
 
 
-def test_extract_batch_size():
-    batch_size = 3
+class TestExtract:
+    def test_batch_size(self):
+        batch_size = 3
 
-    batched_image = torch.zeros(batch_size, 1, 1, 1)
-    actual = image_.extract_batch_size(batched_image)
-    desired = batch_size
-    assert actual == desired
+        batched_image = torch.zeros(batch_size, 1, 1, 1)
+        actual = image_.extract_batch_size(batched_image)
+        desired = batch_size
+        assert actual == desired
 
-    single_image = torch.zeros(1, 1, 1)
-    with pytest.raises(TypeError):
-        image_.extract_batch_size(single_image)
+        single_image = torch.zeros(1, 1, 1)
+        with pytest.raises(TypeError):
+            image_.extract_batch_size(single_image)
 
+    def test_num_channels(self):
+        num_channels = 3
 
-def test_extract_num_channels():
-    num_channels = 3
+        single_image = torch.zeros(num_channels, 1, 1)
+        actual = image_.extract_num_channels(single_image)
+        desired = num_channels
+        assert actual == desired
 
-    single_image = torch.zeros(num_channels, 1, 1)
-    actual = image_.extract_num_channels(single_image)
-    desired = num_channels
-    assert actual == desired
+        batched_image = single_image.unsqueeze(0)
+        actual = image_.extract_num_channels(batched_image)
+        desired = num_channels
+        assert actual == desired
 
-    batched_image = single_image.unsqueeze(0)
-    actual = image_.extract_num_channels(batched_image)
-    desired = num_channels
-    assert actual == desired
+    def test_image_size(self):
+        height = 2
+        width = 3
+        image = torch.empty(1, 1, height, width)
 
+        actual = image_.extract_image_size(image)
+        desired = (height, width)
+        assert actual == desired
 
-def test_extract_image_size():
-    height = 2
-    width = 3
-    image = torch.empty(1, 1, height, width)
+    def test_edge_size(self):
+        height = 2
+        width = 3
+        image = torch.empty(1, 1, height, width)
 
-    actual = image_.extract_image_size(image)
-    desired = (height, width)
-    assert actual == desired
+        edges = ("short", "long", "vert", "horz")
+        actual = tuple(image_.extract_edge_size(image, edge=edge) for edge in edges)
+        desired = (height, width, height, width)
+        assert actual == desired
 
+    def test_aspect_ratio(self):
+        height = 2
+        width = 3
+        image = torch.empty(1, 1, height, width)
 
-def test_extract_edge_size():
-    height = 2
-    width = 3
-    image = torch.empty(1, 1, height, width)
-
-    edges = ("short", "long", "vert", "horz")
-    actual = tuple(image_.extract_edge_size(image, edge=edge) for edge in edges)
-    desired = (height, width, height, width)
-    assert actual == desired
-
-
-def test_extract_aspect_ratio():
-    height = 2
-    width = 3
-    image = torch.empty(1, 1, height, width)
-
-    actual = image_.extract_aspect_ratio(image)
-    desired = width / height
-    assert actual == pytest.approx(desired)
+        actual = image_.extract_aspect_ratio(image)
+        desired = width / height
+        assert actual == pytest.approx(desired)
 
 
-def test_make_batched_image():
-    single_image = torch.empty(1, 1, 1)
-    batched_image = image_.make_batched_image(single_image)
-    assert image_.is_batched_image(batched_image)
-
-
-def test_make_single_image():
-    batched_image = torch.empty(1, 1, 1, 1)
-    single_image = image_.make_single_image(batched_image)
-    assert image_.is_single_image(single_image)
-
-    batched_image = torch.empty(2, 1, 1, 1)
-    with pytest.raises(RuntimeError):
-        image_.make_single_image(batched_image)
-
-
-def test_force_image():
-    @image_.force_image
-    def identity(image):
-        return image
-
-    single_image = torch.empty(1, 1, 1)
-    batched_image = torch.empty(1, 1, 1, 1)
-
-    assert identity(single_image) is single_image
-    assert identity(batched_image) is batched_image
-
-    with pytest.raises(TypeError):
-        identity(None)
-
-
-def test_force_single_image():
-    @image_.force_single_image
-    def identity(single_image):
-        assert image_.is_single_image(single_image)
-        return single_image
-
-    single_image = torch.empty(1, 1, 1)
-    batched_image = torch.empty(1, 1, 1, 1)
-
-    assert identity(single_image) is single_image
-    ptu.assert_allclose(identity(batched_image), batched_image)
-
-    with pytest.raises(TypeError):
-        identity(None)
-
-
-def test_force_batched_image():
-    @image_.force_batched_image
-    def identity(batched_image):
+class TestMakeImage:
+    def test_batched_image(self):
+        single_image = torch.empty(1, 1, 1)
+        batched_image = image_.make_batched_image(single_image)
         assert image_.is_batched_image(batched_image)
-        return batched_image
 
-    single_image = torch.empty(1, 1, 1)
-    batched_image = torch.empty(1, 1, 1, 1)
+    def test_single_image(self):
+        batched_image = torch.empty(1, 1, 1, 1)
+        single_image = image_.make_single_image(batched_image)
+        assert image_.is_single_image(single_image)
 
-    ptu.assert_allclose(identity(single_image), single_image)
-    assert identity(batched_image) is batched_image
+        batched_image = torch.empty(2, 1, 1, 1)
+        with pytest.raises(RuntimeError):
+            image_.make_single_image(batched_image)
 
-    with pytest.raises(TypeError):
-        identity(None)
+
+class TestForceImage:
+    def test_image(self):
+        @image_.force_image
+        def identity(image):
+            return image
+
+        single_image = torch.empty(1, 1, 1)
+        batched_image = torch.empty(1, 1, 1, 1)
+
+        assert identity(single_image) is single_image
+        assert identity(batched_image) is batched_image
+
+        with pytest.raises(TypeError):
+            identity(None)
+
+    def test_single_image(self):
+        @image_.force_single_image
+        def identity(single_image):
+            assert image_.is_single_image(single_image)
+            return single_image
+
+        single_image = torch.empty(1, 1, 1)
+        batched_image = torch.empty(1, 1, 1, 1)
+
+        assert identity(single_image) is single_image
+        ptu.assert_allclose(identity(batched_image), batched_image)
+
+        with pytest.raises(TypeError):
+            identity(None)
+
+    def test_batched_image(self):
+        @image_.force_batched_image
+        def identity(batched_image):
+            assert image_.is_batched_image(batched_image)
+            return batched_image
+
+        single_image = torch.empty(1, 1, 1)
+        batched_image = torch.empty(1, 1, 1, 1)
+
+        ptu.assert_allclose(identity(single_image), single_image)
+        assert identity(batched_image) is batched_image
+
+        with pytest.raises(TypeError):
+            identity(None)

--- a/tests/integration/loss/test_functional.py
+++ b/tests/integration/loss/test_functional.py
@@ -6,32 +6,32 @@ from torch.nn.functional import mse_loss
 import pystiche.loss.functional as F
 
 
-def test_mrf_loss():
-    torch.manual_seed(0)
-    zero_patch = torch.zeros(4, 5, 6)
-    one_patch = torch.ones(4, 5, 6)
-    rand_patch = torch.randn(4, 5, 6)
+class TestMRFLoss:
+    def test_main(self):
+        torch.manual_seed(0)
+        zero_patch = torch.zeros(4, 5, 6)
+        one_patch = torch.ones(4, 5, 6)
+        rand_patch = torch.randn(4, 5, 6)
 
-    input = torch.stack((rand_patch + 0.1, rand_patch * 0.9)).unsqueeze(0)
-    target = torch.stack((zero_patch, one_patch, rand_patch)).unsqueeze(0)
+        input = torch.stack((rand_patch + 0.1, rand_patch * 0.9)).unsqueeze(0)
+        target = torch.stack((zero_patch, one_patch, rand_patch)).unsqueeze(0)
 
-    actual = F.mrf_loss(input, target)
-    desired = mse_loss(input, torch.stack((rand_patch, rand_patch)).unsqueeze(0))
-    ptu.assert_allclose(actual, desired)
+        actual = F.mrf_loss(input, target)
+        desired = mse_loss(input, torch.stack((rand_patch, rand_patch)).unsqueeze(0))
+        ptu.assert_allclose(actual, desired)
 
+    def test_non_batched(self):
+        torch.manual_seed(0)
+        zero_patch = torch.zeros(4, 5, 6)
+        one_patch = torch.ones(4, 5, 6)
+        rand_patch = torch.randn(4, 5, 6)
 
-def test_mrf_loss_non_batched():
-    torch.manual_seed(0)
-    zero_patch = torch.zeros(4, 5, 6)
-    one_patch = torch.ones(4, 5, 6)
-    rand_patch = torch.randn(4, 5, 6)
+        input = torch.stack((rand_patch + 0.1, rand_patch * 0.9))
+        target = torch.stack((zero_patch, one_patch, rand_patch))
 
-    input = torch.stack((rand_patch + 0.1, rand_patch * 0.9))
-    target = torch.stack((zero_patch, one_patch, rand_patch))
-
-    actual = F.mrf_loss(input, target, batched_input=False)
-    desired = mse_loss(input, torch.stack((rand_patch, rand_patch)))
-    ptu.assert_allclose(actual, desired)
+        actual = F.mrf_loss(input, target, batched_input=False)
+        desired = mse_loss(input, torch.stack((rand_patch, rand_patch)))
+        ptu.assert_allclose(actual, desired)
 
 
 def test_value_range_loss_zero():

--- a/tests/integration/loss/test_perceptual.py
+++ b/tests/integration/loss/test_perceptual.py
@@ -6,40 +6,40 @@ from torch import nn
 from pystiche import enc, loss, ops
 
 
-def test_PerceptualLoss_set_content_image():
-    torch.manual_seed(0)
-    image = torch.rand(1, 1, 100, 100)
-    content_loss = ops.FeatureReconstructionOperator(
-        enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
-    )
-    style_loss = ops.FeatureReconstructionOperator(
-        enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
-    )
+class TestPerceptualLoss:
+    def test_set_content_image(self):
+        torch.manual_seed(0)
+        image = torch.rand(1, 1, 100, 100)
+        content_loss = ops.FeatureReconstructionOperator(
+            enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
+        )
+        style_loss = ops.FeatureReconstructionOperator(
+            enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
+        )
 
-    perceptual_loss = loss.PerceptualLoss(content_loss, style_loss)
-    perceptual_loss.set_content_image(image)
+        perceptual_loss = loss.PerceptualLoss(content_loss, style_loss)
+        perceptual_loss.set_content_image(image)
 
-    actual = content_loss.target_image
-    desired = image
-    ptu.assert_allclose(actual, desired)
+        actual = content_loss.target_image
+        desired = image
+        ptu.assert_allclose(actual, desired)
 
+    def test_set_style_image(self):
+        torch.manual_seed(0)
+        image = torch.rand(1, 1, 100, 100)
+        content_loss = ops.FeatureReconstructionOperator(
+            enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
+        )
+        style_loss = ops.FeatureReconstructionOperator(
+            enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
+        )
 
-def test_PerceptualLoss_set_style_image():
-    torch.manual_seed(0)
-    image = torch.rand(1, 1, 100, 100)
-    content_loss = ops.FeatureReconstructionOperator(
-        enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
-    )
-    style_loss = ops.FeatureReconstructionOperator(
-        enc.SequentialEncoder((nn.Conv2d(1, 1, 1),))
-    )
+        perceptual_loss = loss.PerceptualLoss(content_loss, style_loss)
+        perceptual_loss.set_style_image(image)
 
-    perceptual_loss = loss.PerceptualLoss(content_loss, style_loss)
-    perceptual_loss.set_style_image(image)
-
-    actual = style_loss.target_image
-    desired = image
-    ptu.assert_allclose(actual, desired)
+        actual = style_loss.target_image
+        desired = image
+        ptu.assert_allclose(actual, desired)
 
 
 def test_GuidedPerceptualLoss(subtests):


### PR DESCRIPTION
Addresses #509 :)
A few places where I was skeptical about the grouping of tests, I have mentioned them below