### PR TITLE
fix gallery builds

### DIFF
--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,11 +1,11 @@
 sphinx >= 3
 importlib-metadata
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex == 2
 sphinx_autodoc_typehints >= 1.11
 pydata_sphinx_theme
-sphinx-gallery>=0.8
+jinja2
+sphinx-gallery >=0.8, <0.10
 matplotlib
 memory_profiler
-jinja2
-https://download.pytorch.org/whl/cpu/torch-1.9.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
-https://download.pytorch.org/whl/cpu/torchvision-0.10.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
+https://download.pytorch.org/whl/cpu/torch-1.10.0%2Bcpu-cp36-cp36m-linux_x86_64.whl
+https://download.pytorch.org/whl/cpu/torchvision-0.11.1%2Bcpu-cp36-cp36m-linux_x86_64.whl

--- a/scripts/generate_requirements_rtd.py
+++ b/scripts/generate_requirements_rtd.py
@@ -5,6 +5,7 @@ from os import path
 try:
     import light_the_torch as ltt
     import yaml
+    from light_the_torch.computation_backend import CPUBackend
 
     assert ltt.__version__ >= "0.2"
 except (ImportError, AssertionError):
@@ -23,7 +24,7 @@ def main(
     deps = extract_docs_deps_from_tox_config(root)
     deps.extend(find_pytorch_wheel_links(root, python_version))
 
-    with open(file, "w") as fh:
+    with open(path.join(root, file), "w") as fh:
         fh.write("\n".join(deps) + "\n")
 
 
@@ -51,11 +52,11 @@ def extract_docs_deps_from_tox_config(root, file="tox.ini", section="docs-common
 
 
 def find_pytorch_wheel_links(
-    root, python_version, computation_backend="cpu", platform="linux_x86_64",
+    root, python_version, computation_backend=CPUBackend(), platform="linux_x86_64",
 ):
     return ltt.find_links(
         [root],
-        computation_backend=computation_backend,
+        computation_backends=computation_backend,
         python_version=python_version,
         platform=platform,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands =
 
 [sphinx-gallery]
 deps =
-  sphinx-gallery>=0.8
+  sphinx-gallery >=0.8, <0.10
   # Additional sphinx-gallery dependencies
   # https://sphinx-gallery.github.io/stable/index.html#install-via-pip
   matplotlib


### PR DESCRIPTION
This PR does 3 things:

- revert accidental change from #583 that disables patching `tqdm` in the galleries
- pin `sphinx-gallery<0.10.0`, because with the latest versions the images are not showing up in the documentation. See sphinx-gallery/sphinx-gallery#878
- Fix the script that generates RTD requirements