### PR TITLE
reenable tdqm patch for gallery builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -298,7 +298,7 @@ def sphinx_gallery():
     config = dict(sphinx_gallery_conf=sphinx_gallery_conf)
     filter_warnings()
 
-    # patch_tqdm()
+    patch_tqdm()
     filter_warnings()
 
     return extension, config


### PR DESCRIPTION
Revert accidental change from #583 that disables patching `tqdm` in the galleries