### PR TITLE
Changed flake8 location from gitlab to github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: black
         args: [--config=pyproject.toml]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: "3.8.3"
     hooks:
       - id: flake8


### PR DESCRIPTION
I couldn't commit changes with the gitlab flake8 repo specified. Changing to the github one resolved this.