### PR TITLE
fix pyramid for nested losses

### DIFF
--- a/pystiche/pyramid/pyramid.py
+++ b/pystiche/pyramid/pyramid.py
@@ -108,15 +108,13 @@ class ImagePyramid(ComplexObject):
                 loss_.set_input_guide(resized_guide)
 
     def _resize_losses(self) -> Set[loss.Loss]:
-        resize_losses = set()
-        for target in self._resize_targets:
-            if isinstance(target, loss.Loss):
-                resize_losses.add(target)
-
-            for loss_ in target._losses():
-                if not isinstance(loss_, loss.LossContainer):
-                    resize_losses.add(loss_)
-        return resize_losses
+        return {
+            loss_
+            for target in self._resize_targets
+            for loss_ in target.modules()
+            if isinstance(loss_, loss.Loss)
+            and not isinstance(loss_, loss.LossContainer)
+        }
 
     def _properties(self) -> Dict[str, Any]:
         dct = super()._properties()


### PR DESCRIPTION
Before #500, the pyramid recursed through the loss to find all leaf nodes:

https://github.com/pystiche/pystiche/blob/be4c38db3e94f196d93f31be1a66c43da017de9f/pystiche/pyramid/pyramid.py#L113-L119

Now, this recursion is gone 

https://github.com/pystiche/pystiche/blob/7726e3d6543e39e55b51c37f733d26daeff68cfd/pystiche/pyramid/pyramid.py#L112-L118

This patch readds it.