### PR TITLE
fix (de)normalize to work for arbitrary batch dimensions

### DIFF
--- a/pystiche/enc/prepostprocessing.py
+++ b/pystiche/enc/prepostprocessing.py
@@ -20,7 +20,11 @@ __all__ = [
 
 
 class _Normalization(pystiche.Module):
-    def __init__(self, mean: Sequence[float], std: Sequence[float],) -> None:
+    def __init__(
+        self,
+        mean: Sequence[float],
+        std: Sequence[float],
+    ) -> None:
         super().__init__()
         self.mean = mean
         self.std = std
@@ -38,7 +42,10 @@ class _Normalization(pystiche.Module):
                     f"channels do not match: {len(seq)} != {num_channels}"
                 )
                 raise RuntimeError(msg)
-            return torch.tensor(seq, device=image.device).view(1, -1, 1, 1)
+
+            shape = [1] * image.ndim
+            shape[-3] = len(seq)
+            return torch.tensor(seq, dtype=image.dtype, device=image.device).view(shape)
 
         return to_tensor(mean), to_tensor(std)
 

--- a/pystiche/enc/prepostprocessing.py
+++ b/pystiche/enc/prepostprocessing.py
@@ -20,11 +20,7 @@ __all__ = [
 
 
 class _Normalization(pystiche.Module):
-    def __init__(
-        self,
-        mean: Sequence[float],
-        std: Sequence[float],
-    ) -> None:
+    def __init__(self, mean: Sequence[float], std: Sequence[float]) -> None:
         super().__init__()
         self.mean = mean
         self.std = std


### PR DESCRIPTION
With this all pre- and postprocessing ops can handle inputs with arbitrary batch sizes.